### PR TITLE
Fix test assertions that compared values to themselves

### DIFF
--- a/test_includex.py
+++ b/test_includex.py
@@ -74,10 +74,10 @@ def add_filepath_to_doctest(doctest_namespace, testfile):
 
 def test_include_full_file(testfile):
     """Include all content from file."""
-    expected = content
+    expected = content.rstrip()
     returned = includex(testfile)
     print_debug(expected, returned)
-    assert returned == returned
+    assert returned == expected
 
 
 def test_include_first_lines(testfile):
@@ -85,7 +85,7 @@ def test_include_first_lines(testfile):
     expected = "\n".join(content.split("\n")[:5])
     returned = includex(testfile, lines=5)
     print_debug(expected, returned)
-    assert returned == returned
+    assert returned == expected
 
 
 @pytest.mark.parametrize(("start", "end"), [(2, 5)])


### PR DESCRIPTION
## Summary

- Fixed two test assertions that were comparing `returned == returned` instead of `returned == expected`
- Added `.rstrip()` to `test_include_full_file` expected value to match actual `includex()` behavior

## Details

The tests `test_include_full_file` and `test_include_first_lines` had broken assertions that always passed regardless of actual behavior. Fixing them revealed that `test_include_full_file` also needed to account for `includex()` stripping trailing whitespace.

All 76 tests pass.