### PR TITLE
fix: correct test assertions and expectations

### DIFF
--- a/test_includex.py
+++ b/test_includex.py
@@ -74,10 +74,10 @@ def add_filepath_to_doctest(doctest_namespace, testfile):
 
 def test_include_full_file(testfile):
     """Include all content from file."""
-    expected = content
+    expected = content.rstrip()
     returned = includex(testfile)
     print_debug(expected, returned)
-    assert returned == returned
+    assert returned == expected
 
 
 def test_include_first_lines(testfile):
@@ -85,7 +85,7 @@ def test_include_first_lines(testfile):
     expected = "\n".join(content.split("\n")[:5])
     returned = includex(testfile, lines=5)
     print_debug(expected, returned)
-    assert returned == returned
+    assert returned == expected
 
 
 @pytest.mark.parametrize(("start", "end"), [(2, 5)])


### PR DESCRIPTION
## Summary
- Fixed two test functions that were comparing `returned` to itself instead of to the expected value
- Added `.rstrip()` to `test_include_full_file` to match the documented behavior of stripping trailing whitespace
- Both assertions now properly validate the returned content

## Changes
- `test_include_full_file`: Fixed assertion and updated expected value
- `test_include_first_lines`: Fixed assertion to validate against expected content

## Testing
✅ All 76 tests pass with no regressions

## Details
These tests were unable to catch regressions because they compared `returned == returned` instead of `returned == expected`. The fix ensures these tests properly validate the `includex` function's behavior.