### PR TITLE
Fix tautological assertion in test_include_full_file

### DIFF
--- a/test_includex.py
+++ b/test_includex.py
@@ -74,10 +74,10 @@ def add_filepath_to_doctest(doctest_namespace, testfile):
 
 def test_include_full_file(testfile):
     """Include all content from file."""
-    expected = content
+    expected = content.rstrip()  # includex strips trailing whitespace by default
     returned = includex(testfile)
     print_debug(expected, returned)
-    assert returned == returned
+    assert returned == expected
 
 
 def test_include_first_lines(testfile):


### PR DESCRIPTION
## Summary

- Fixed tautological assertion `assert returned == returned` (always passes)
- Changed to `assert returned == expected` to properly validate function behavior
- Updated expected value to use `content.rstrip()` since `includex()` strips trailing whitespace by default

## Details

The test `test_include_full_file` had a bug where it was comparing `returned == returned`, which always evaluates to `True` regardless of the actual function output. This meant the test was not actually validating anything.

When corrected to `assert returned == expected`, the test initially failed because the expected value included a trailing newline but `includex()` strips trailing whitespace by design (as documented in the function docstring at includex.py:71-72).

## Testing

All 76 tests pass across Python 3.8, 3.9, 3.10, and 3.11 with 97% coverage:
```
======================== 76 passed, 4 warnings ========================
```